### PR TITLE
Clean up installation paragraph

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,16 +119,17 @@ echo "after run()\n";</code></pre>
 	</script>
 
 	<h2 id="installation">Installation</h2>
-
 	<p>
-		We already have a good set of libraries and packages you can use. Not all of them have a documentation
-		yet, <a href="https://github.com/amphp/amphp.github.io">you're welcome to help</a>. You can install all
-		our libraries using <a href="https://getcomposer.org">Composer</a>. Just have a look at the blue top
-		menu listing the packages. It's indicated whether they have documentation here already or not through
-		the icon on the right.
+		We already have a good set of libraries and packages you can use, which can be found using the
+		"packages" menu at the top of this page. These libraries can all be installed using 
+		<a href="https://getcomposer.org">Composer</a>.
 	</p>
-
 	<pre><code class="language-bash" id="install">composer require amphp/amp</code></pre>
+	<p>
+		Note that not all of the libraries are documented yet. Libraries that have documentation are shown with
+		a <i class="fa fa-book"></i> icon next to them. You're welcome to help with missing documentation
+		<a href="https://github.com/amphp/amphp.github.io">on GitHub</a>.
+	</p>
 
 	<script>
 		var install = document.getElementById("install");


### PR DESCRIPTION
The English in this paragraph is a bit awkward. Additionally, it's mostly talking about documentation, but randomly mentions Composer in the middle. I split it into two separate paragraphs - One about installation through Composer, and one about documentation.

Before:
![](http://ss.dan.cx/2017/02/Welcome_to_asynchronous_multitasking_PHP_%E2%8B%85_amphp_-_04-23.04.40.png)

After:
![](http://ss.dan.cx/2017/02/Welcome_to_asynchronous_multitasking_PHP_%E2%8B%85_amphp_-_04-23.03.48.png)